### PR TITLE
add run configurations for CLion

### DIFF
--- a/.run/stereo-vision-calibrate (lighthouse).run.xml
+++ b/.run/stereo-vision-calibrate (lighthouse).run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="stereo-vision-calibrate (lighthouse)" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="$ContentRoot$/resources/calibration/lighthouse-simulation" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="stereo_vision" TARGET_NAME="stereo-vision-calibrate" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="stereo_vision" RUN_TARGET_NAME="stereo-vision-calibrate">
+    <method v="2">
+      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/stereo-vision-static-image (folder).run.xml
+++ b/.run/stereo-vision-static-image (folder).run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="stereo-vision-static-image (folder)" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="$ContentRoot$/resources/calibration/lighthouse-simulation" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="stereo_vision" TARGET_NAME="stereo-vision-static-image" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="stereo_vision" RUN_TARGET_NAME="stereo-vision-static-image">
+    <method v="2">
+      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/stereo-vision-static-image (image pair).run.xml
+++ b/.run/stereo-vision-static-image (image pair).run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="stereo-vision-static-image (image pair)" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="$ContentRoot$/resources/calibration/lighthouse-simulation/left/000.png $ContentRoot$/resources/calibration/lighthouse-simulation/right/000.png $ContentRoot$/resources/calibration/lighthouse-simulation/calibration.yml" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="stereo_vision" TARGET_NAME="stereo-vision-static-image" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="stereo_vision" RUN_TARGET_NAME="stereo-vision-static-image">
+    <method v="2">
+      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>


### PR DESCRIPTION
this makes it easier to just launch the project for the lighthouse examples. the paths are relative to the project and thus work on all computers.

the files were generated by CLion.