### PR TITLE
manually add fix for GLIBC++ bug 117560

### DIFF
--- a/apps/calibrate/main.cpp
+++ b/apps/calibrate/main.cpp
@@ -7,6 +7,7 @@
 #include <opencv2/opencv.hpp>
 #include <opencv2/core/utils/logger.hpp>
 
+#include <gcc-bug-117560-workaround.hpp>
 #include <stereo-vision-lib/StereoCameraInfo.hpp>
 
 /// Temporary helper to help with re-scaling for easy display.
@@ -199,7 +200,7 @@ auto CalibrationRun::RunCalibration(std::ranges::range auto const& images_left, 
   if (this->config_.report_progress) {
     std::cout << "Processing images";
   }
-#ifndef __GLIBCXX__
+
   for (auto const& [image_left, image_right] : std::views::zip(images_left, images_right)) {
     this->ProcessImage(image_left, object_points_left, image_points_left, "ongoing calibration, left");
     this->ProcessImage(image_right, object_points_right, image_points_right, "ongoing calibration, right");
@@ -208,21 +209,7 @@ auto CalibrationRun::RunCalibration(std::ranges::range auto const& images_left, 
       std::cout << ".";
     }
   }
-#else
-  // WORKAROUND: we can't use `std::views::zip` here at the moment due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117560
-  for (auto const& image_left : images_left) {
-    this->ProcessImage(image_left, object_points_left, image_points_left, "ongoing calibration, left");
-    if (this->config_.report_progress) {
-      std::cout << ".";
-    }
-  }
-  for (auto const& image_right : images_right) {
-    this->ProcessImage(image_right, object_points_left, image_points_left, "ongoing calibration, right");
-    if (this->config_.report_progress) {
-      std::cout << ".";
-    }
-  }
-#endif
+
   if (this->config_.report_progress) {
     std::cout << " done" << std::endl;
     std::cout << "Calculating...";

--- a/apps/static-image/main.cpp
+++ b/apps/static-image/main.cpp
@@ -10,6 +10,7 @@
 #include <opencv2/opencv.hpp>
 #include <opencv2/core/utils/logger.hpp>
 
+#include <gcc-bug-117560-workaround.hpp>
 #include <stereo-vision-lib/lib.hpp>
 
 /// Input parameters if a folder was chosen.
@@ -128,18 +129,12 @@ void ProcessFolderPath(FolderPath const& folder_path) {
     return cv::imread(e.path().string(), cv::IMREAD_COLOR);
   };
 
-#ifndef __GLIBCXX__
-
   auto images_left = std::filesystem::directory_iterator{folder_left} | std::views::transform(directory_entry_to_image);
   auto images_right = std::filesystem::directory_iterator{folder_right} | std::views::transform(directory_entry_to_image);
 
   for (auto const& [image_left, image_right] : std::views::zip(images_left, images_right)) {
     ProcessImagePair(stereo_vis, image_left, image_right);
   }
-#else
-#warning libstdc++ from GCC is affected by a bug (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117560) which prevents using static-image with a folder path. Use libc++ from LLVM or MSVC to use it! Calling this will crash at runtime!
-  throw std::runtime_error("Folder path is unsupported due to a libstdc++ bug! Recompilewith libc++ from LLVM or MSVC to use this functionality!");
-#endif
 }
 
 /**

--- a/include/gcc-bug-117560-workaround.hpp
+++ b/include/gcc-bug-117560-workaround.hpp
@@ -1,0 +1,34 @@
+#ifndef GCC_BUG_117560_WORKAROUND_HPP
+#define GCC_BUG_117560_WORKAROUND_HPP
+
+#if defined(__GLIBCXX__) && __GLIBCXX__ <= 20240908
+  // see: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117560
+  // patch taken from here: https://gcc.gnu.org/git/?p=gcc.git;a=blobdiff;f=libstdc%2B%2B-v3/include/bits/fs_dir.h;h=79dc6764b7b27bb7b6d2ed6dda93b5f5e164ea29;hp=d669f2a74681509d769c62271d10f50beca89b0b;hb=eec6e8923586b9a54e37f32cef112d26d86e8f01;hpb=9ede072ffafcde27d0e9fe76bb7ffacb4f48a2d6
+  // once GCC 14.3.0 has been released this should be removed and GCC users should upgrade.
+
+  // Copyright (C) 2014-2024 Free Software Foundation, Inc.
+  // SPDX-License-Identifier: GPL-3.0-or-later
+
+  namespace std {
+    // _GLIBCXX_RESOLVE_LIB_DEFECTS
+    // 3480. directory_iterator and recursive_directory_iterator are not ranges
+    namespace ranges
+    {
+      template<>
+        inline constexpr bool
+        enable_borrowed_range<filesystem::directory_iterator> = true;
+      template<>
+        inline constexpr bool
+        enable_borrowed_range<filesystem::recursive_directory_iterator> = true;
+
+      template<>
+        inline constexpr bool
+        enable_view<filesystem::directory_iterator> = true;
+      template<>
+        inline constexpr bool
+        enable_view<filesystem::recursive_directory_iterator> = true;
+    } // namespace ranges
+  }
+#endif
+
+#endif //GCC_BUG_117560_WORKAROUND_HPP


### PR DESCRIPTION
this is a 1:1 copy of the fix from GLIBC++ and it is only being applied on GLIBC++ versions which are known to be affected (presuming that no new GLIBC++ releases will be created without the fix). the latest release (affected) is 14.2.0, the fix should be in 14.3.0.

this way we don't need a workaround for the calibration tool and can use the folder functionality of the static image viewer also with GCC.